### PR TITLE
Added a way for the user to change the starting position

### DIFF
--- a/pseudoAuto.java
+++ b/pseudoAuto.java
@@ -9,6 +9,23 @@ int startingPos
 //Switch Determination
 //Manually input the startingPos somehow??? idk if thats even possible
 
+//Send an option for the starting position to the smart dashboard, in practice, this should be done in disabledPeriodic(), the value will start off as one
+SmartDashboard.putNumber("Starting Pos", 1);
+
+// Get the selection from the smart dashboard, if no selection is found, return 1
+startingPos = (int)SmartDashboard.getNumber("Starting Pos", 1);
+
+
+// Make sure that the starting position is valid to avoid errors
+// This is not a very good way of doing it, i am just trying to demonstrate how you would get user input
+if(startingPos > 3){
+	startingPos = 3;
+}else if(startingPos < 0){
+	startingPos = 0;
+}
+
+
+
 if (gameData.getAt(0) == 'L'){
   switch (startingPos){
     case 1:


### PR DESCRIPTION
By using the smart dashboard, now [shuffleboard](https://github.com/wpilibsuite/shuffleboard), the user can select which starting position, by creating a start position option and then getting the value later on. Another way to do this would be to have a sendable chooser, which is less error-prone, but slightly more complicated.